### PR TITLE
Calculate and scale luminance values

### DIFF
--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -19,6 +19,16 @@
 #include "MPIConverter.h"
 #include "MainWindow.h"
 
+
+// calculate relative luminance for RGB colorspace: https://en.wikipedia.org/wiki/Relative_luminance
+constexpr uint8_t calculate_rgb_luminance(uint8_t red, uint8_t green, uint8_t blue)
+{
+  return
+      0.2126 * float(red) +
+      0.7152 * float(green) +
+      0.0722 * float(blue);
+}
+
 extern const uint32_t COLOUR_FOR_TRANSPARENT;
 // Constructor of the main Window (build ui interface).
 MainWindow::MainWindow( std::string filename, uint32_t alphaColor, bool blackWhite ) : Window()
@@ -27,14 +37,16 @@ MainWindow::MainWindow( std::string filename, uint32_t alphaColor, bool blackWhi
 	this->set_border_width(10);
 
 	Glib::RefPtr<Gdk::Pixbuf> piximage = Gdk::Pixbuf::create_from_file(filename);
+  g_assert(piximage.get()->get_colorspace() == Gdk::COLORSPACE_RGB); // this could only be triggered if they change the API
+
 	uint32_t pixOffset = 0;
-	uint32_t offset = 0;
-	uint8_t* pixBuffer = piximage.get()->get_pixels();
-	uint32_t pixRowstride = piximage.get()->get_rowstride();
-	uint32_t pixWidth = piximage.get()->get_width();
-	uint32_t pixHeight = piximage.get()->get_height();
-	uint32_t pixPixelSize = piximage.get()->get_n_channels();
-        bool pixHasAlpha = piximage.get()->get_has_alpha();
+  uint32_t offset = 0;
+  uint8_t* const pixBuffer = piximage.get()->get_pixels();
+  const uint32_t pixRowstride = piximage.get()->get_rowstride();
+  const uint32_t pixWidth = piximage.get()->get_width();
+  const uint32_t pixHeight = piximage.get()->get_height();
+  const uint32_t pixPixelSize = piximage.get()->get_n_channels();
+  const bool pixHasAlpha = piximage.get()->get_has_alpha();
 
 	std::cout<<"rowstride: "<<pixRowstride<<std::endl;
 	std::cout<<"width: "<<pixWidth<<std::endl;
@@ -43,6 +55,22 @@ MainWindow::MainWindow( std::string filename, uint32_t alphaColor, bool blackWhi
 	std::cout<<"black&white: "<<(blackWhite?"true":"false")<<std::endl;
 	std::cout<<"has alpha? : "<<(pixHasAlpha?"true":"false")<<std::endl;
 
+
+  constexpr uint32_t red_channel = 0;
+  constexpr uint32_t green_channel = 1;
+  constexpr uint32_t blue_channel = 2;
+
+  bool grayscale_image = true;
+
+  for( uint32_t y=0; y<pixHeight; ++y ) {
+    pixOffset = y * pixRowstride; // in case of `pixPixelSize` and `pixWidth` being both odd, there is at least one additional byte at the end of each row that should be discarded. Probable cause: uintX_t (uint16_t?) -> uint8_t array conversion in gdkmm-3.0 lib
+    for( uint32_t x=0; x<pixWidth; ++x ) {
+      if(pixBuffer[pixOffset + red_channel] != pixBuffer[pixOffset + green_channel] || // all the channels are the same value
+         pixBuffer[pixOffset + red_channel] != pixBuffer[pixOffset + blue_channel])
+        grayscale_image = false;
+      pixOffset+=pixPixelSize;
+    }
+  }
 
 	//convert to byte per pixel representation
 	uint32_t pixel = 0;
@@ -53,7 +81,16 @@ MainWindow::MainWindow( std::string filename, uint32_t alphaColor, bool blackWhi
 	for( uint32_t y=0; y<pixHeight; ++y ) {
         pixOffset = y * pixRowstride; // in case of `pixPixelSize` and `pixWidth` being both odd, there is at least one additional byte at the end of each row that should be discarded. Probable cause: uintX_t (uint16_t?) -> uint8_t array conversion in gdkmm-3.0 lib
 		for( uint32_t x=0; x<pixWidth; ++x ) {
-			pixel8 = static_cast<uint8_t>((*(pixBuffer + pixOffset)) & 0x000000FF); // luminosity as a single byte. this whole cast is actually not needed, as pixBuffer is uint8_t. Here reading actually red channel
+      if(grayscale_image) // use value as luminance
+        pixel8 = pixBuffer[pixOffset];
+      else // calculate relative luminance from color: https://en.wikipedia.org/wiki/Relative_luminance
+      {
+        pixel8 = calculate_rgb_luminance(
+                   pixBuffer[pixOffset + red_channel],
+                   pixBuffer[pixOffset + green_channel],
+                   pixBuffer[pixOffset + blue_channel]);
+      }
+
                   bool transparent = false;
                   if (pixHasAlpha) {
                     // then the last channel is alpha
@@ -64,14 +101,20 @@ MainWindow::MainWindow( std::string filename, uint32_t alphaColor, bool blackWhi
 
                   if (transparent) {
                     pixel8 = COLOUR_FOR_TRANSPARENT;
-                  } else {
-                    pixel8 >>= 4;
-                    if (blackWhite) {
-                      if (pixel8 > 7)
-                        pixel8 = 15;
-                      else
-                        pixel8 = 0;
-                    }
+                  } else if (blackWhite) {
+                    if (pixel8 & 0x80)
+                      pixel8 = 15;
+                    else
+                      pixel8 = 0;
+                  } else { // luminence scaling
+                    constexpr double maxColorValue = 15.0;
+                    constexpr double oldMaxColorValue = 255.0;
+                    double val = pixel8;
+                    val *= maxColorValue;
+                    val += oldMaxColorValue / 2.0;
+                    val /= oldMaxColorValue;
+                    val = std::floor(val);
+                    pixel8 = val;
                   }
                   buffer[offset] = pixel8;
 			++offset;


### PR DESCRIPTION
The image is tested to see if it's grayscale. If it is not then the luminance value is calculated. In all cases, the luminance is scaled
down to four bits instead of being truncated.

This shows the difference in the old luminance truncation algorithm versus the new luminance scaling algorithm.

![demo](https://user-images.githubusercontent.com/670534/181933509-8d6c3d03-d3a8-4be0-954e-3566918495a6.gif)

The new algorithm preserves more of the detail which is why it appears to be stretched.